### PR TITLE
board-to-string

### DIFF
--- a/src/othello/core.clj
+++ b/src/othello/core.clj
@@ -71,7 +71,7 @@
              (let [board (string-to-board ".W."
                                           "BW "
                                           "W  ")]
-               (is (board-to-string board) ".W.\nBW\nW")))}
+               (is (= (board-to-string board) ".W.\nBW \nW  \n"))))}
   board-to-string [board]
   (let [max-x (max-coordinate board 0)
         max-y (max-coordinate board 1)]

--- a/src/othello/core.clj
+++ b/src/othello/core.clj
@@ -66,7 +66,7 @@
                [[x y] occupant]))))
 
 (defn
-  #^{:doc  "A nice string version of the board"
+  #^{:doc  "A nice string version of the board."
      :test (fn []
              (let [board (string-to-board ".W."
                                           "BW "

--- a/src/othello/core.clj
+++ b/src/othello/core.clj
@@ -75,15 +75,15 @@
   board-to-string [board]
   (let [max-x (max-coordinate board 0)
         max-y (max-coordinate board 1)]
-    (for
-      [x (range (inc max-x))
-       y (range (inc max-y))
-       :let [occupant (get-occupant board x y)]]
-      (cond
-        (and (nil? occupant) (= max-y y)) " \n"
-        (nil? occupant) " "
-        (= max-y y) (str occupant "\n")
-        :else occupant))))
+    (apply str (for
+                 [y (range (inc max-y))
+                  x (range (inc max-x))
+                  :let [occupant (get-occupant board x y)]]
+                 (cond
+                   (and (nil? occupant) (= max-x x)) " \n"
+                   (nil? occupant) " "
+                   (= max-x x) (str occupant "\n")
+                   :else occupant)))))
 
 (defn-
   #^{:doc  "Returns true if a player is occupying the node at the given coordinates"


### PR DESCRIPTION
Tyckte det fattades en punkt i docen. 

Testet var felkonstruerat förut, vilket gjorde att det felaktiga svaret inte ansågs som fel. (Den förväntade strängen blev istället meddelandet som visas om ```is``` fick ett falsy värde).

Implementationen loopade på ett sätt som vände på brädet till dess matris-transponat (tror jag, ute på hal is nu känner jag). Sist men inte minst returnerades en lista, när vi istället ville ha en sträng.