### PR TITLE
string-to-board

### DIFF
--- a/src/othello/core.clj
+++ b/src/othello/core.clj
@@ -49,7 +49,9 @@
   (apply max (map #(nth % n) (keys board))))
 
 (defn-
-  #^{:doc  "Creates a board from the given string arguments."
+  #^{:doc
+     "Creates a board from the given string arguments. Input must form a rectangular board, but nodes can be left out
+     with space characters."
      :test (fn []
              (is (= (string-to-board "W..B" " W.." "BBB.")
                     {[0 0] "W" [1 0] "." [2 0] "." [3 0] "B"

--- a/src/othello/core.clj
+++ b/src/othello/core.clj
@@ -59,13 +59,15 @@
                      [0 2] "B" [1 2] "B" [2 2] "B" [3 2] "."})))}
   string-to-board [& string-board]
   ; ([0 ([0 \W] [1 \.] [2 \.] [3 \B])] [1 ([0 \W] [1 \W] [2 \.] [3 \.])] [2 ([0 \B] [1 \B] [2 \B] [3 \.])])
-  (into {} (for [row (map-indexed vector (map #(map-indexed vector (seq %)) string-board))
-                 :let [y (first row)]
-                 x-and-occupant (second row)
-                 :let [x (first x-and-occupant)
-                       occupant (str (second x-and-occupant))]]
-             (when (not= " " occupant)
-               [[x y] occupant]))))
+  (let
+    [indexed-elements (fn [seq] (map-indexed vector seq))]
+    (into {} (for [row (indexed-elements (map indexed-elements string-board))
+                   :let [y (first row)]
+                   x-and-occupant (second row)
+                   :let [x (first x-and-occupant)
+                         occupant (str (second x-and-occupant))]]
+               (when (not= " " occupant)
+                 [[x y] occupant])))))
 
 (defn
   #^{:doc  "A nice string version of the board"


### PR DESCRIPTION
Uppdaterade docen lite angående att input måste vara ett rektangulärt bräde men att man kan skippa noder med space (tog mig en pinsamt lång stund att se mellanslaget i testet).

Jag har också försökt göra for-loopen lite enklare genom att ha en inline funktion. Dessutom har jag tagit bort ```(seq %)```som inte behövs eftersom strängar redan uppfyller ```seq``` (antar jag).

Du får avgöra om det blev bättre eller inte :)  