### PR TITLE
update-board

### DIFF
--- a/src/othello/core.clj
+++ b/src/othello/core.clj
@@ -101,8 +101,12 @@
              (let [board
                    (string-to-board ".W."
                                     "BW.")]
-               (is (update-board board "X" 0 0)
+               (is (mark board "X" 0 0)
                    (string-to-board "XW."
-                                    "BW."))))}
-  update-board [board player x y]
-  (update-in board [[x y]] (fn [arg] player)))
+                                    "BW."))
+               (is (thrown? IllegalArgumentException (mark board "X" 1 0)))))}
+  mark [board player x y]
+  (update-in board [[x y]] (fn [node]
+                             (if (not= node ".")
+                               (throw (IllegalArgumentException. ""))
+                               :player))))


### PR DESCRIPTION
Tyckte denna skulle heta ```mark``` istället. Update skulle kunna göra vad som helst, men eftersom funktionen endast markerar noder så tycker jag det är bättre att vara mer specifik i namnet.

La även till så att den throwar IllegalArgumentException om man försöker markera en nod som redan är markerad.