### PR TITLE
Utils rewrite

### DIFF
--- a/src/othello/state.clj
+++ b/src/othello/state.clj
@@ -3,7 +3,7 @@
   (:require [othello.core :as othello])
   (:use [clojure.test :only (deftest is are run-tests)]
         [clojure.repl :only (doc)]
-        [othello.utils :only (uuid soft-deref)]
+        [utils.core :only (uuid soft-deref)]
         [test.core :only (is=)]))
 
 ; The model

--- a/src/othello/state.clj
+++ b/src/othello/state.clj
@@ -3,7 +3,8 @@
   (:require [othello.core :as othello])
   (:use [clojure.test :only (deftest is are run-tests)]
         [clojure.repl :only (doc)]
-        [othello.utils :only (uuid maps-equal?)]))
+        [othello.utils :only (uuid soft-deref)]
+        [test.core :only (is=)]))
 
 ; The model
 
@@ -31,10 +32,10 @@
                           :id             "game1"}
                    game2 {:board          {[2 2] "B" [3 3] "W"}
                           :players        ["B" "W"]
-                          :player-in-turn "W"
+                          :player-in-turn "B"
                           :id             "game2"}]
-               (is (maps-equal? (create-game {} (game1 :board) (game1 :players) (game1 :id)) {"game1" game1}))
-               (is (maps-equal? (create-game {:game1 game1} (game2 :board) (game2 :players) (game2 :id)) {"game1" game1 "game2" game2}))
+               (is= (soft-deref (create-game {} (game1 :board) (game1 :players) (game1 :id))) {"game1" game1})
+               (is= (soft-deref (create-game {"game1" game1} (game2 :board) (game2 :players) (game2 :id))) {"game2" game2 "game1" game1})
                (is (thrown? IllegalArgumentException (create-game {"game1" {}} nil nil "game1")))))}
   create-game
   [games board players id]

--- a/src/othello/utils.clj
+++ b/src/othello/utils.clj
@@ -2,49 +2,30 @@
   "Assorted utility functions. Might be moved out from Othello package later."
   (:use [clojure.test :only (deftest is are run-tests)]
         [clojure.repl :only (doc)]
+        [clojure.walk :only (postwalk)]
         [test.core :only (is=)]))
 
 (defn
   #^{:doc
-           "Works like clojure.core/deref except that if the given value is not something dereferencable,
-           the value will simply be returned."
+           "Works like clojure.core/deref except that if the given value is not something dereferable,
+           the value will simply be returned. If the given value is a collection, it will be traversed and dereferenced."
      :test (fn []
              (is= (soft-deref "test") "test")
              (is= (soft-deref (atom "test")) "test")
              (is= (soft-deref (ref "test")) "test")
              (is= (soft-deref (agent "test")) "test")
-             (is= (soft-deref nil) nil))}
+             (is= (soft-deref nil) nil)
+             (is= (soft-deref {:test (ref "test")}) {:test "test"})
+             (is= (soft-deref {:outer {:test (ref "test")}}) {:outer {:test "test"}})
+             (is= (soft-deref {:outer (ref {:test (ref "test")})}) {:outer {:test "test"}})
+             (is= (soft-deref (list (atom {:very (ref "nested")}) #{(atom "so") "nested"})) (list {:very "nested"} #{"so" "nested"})))}
   soft-deref
-  [value]
-  (if (instance? clojure.lang.IDeref value)
-    @value
-    value))
-
-(defn
-  #^{:doc
-           "Compares if two maps are equal by value. Dereferences all dereferencable containers for their values
-           before comparing. So this is like a softer version of the closure clojure.core/= function."
-     :test (fn []
-             (is (not (maps-equal? {:test "test" :wrong "key"} {:test "test" :another "key"})))
-             (is (not (maps-equal? {:value (ref "value")} {:value "other"})))
-             (is (maps-equal? {:test (ref "test")} {:test "test"}))
-             (is (maps-equal? {:outer {:test (ref "test")}} {:outer {:test "test"}}))
-             (is (maps-equal? {:outer (ref {:test (ref "test")})} {:outer {:test "test"}})))
-     }
-  maps-equal?
-  [map1 map2]
-  (and
-    (= (count map1) (count map2))
-    (reduce (fn [equal key]
-              (let [value1 (soft-deref (get map1 key))
-                    value2 (soft-deref (get map2 key))]
-                (and
-                  equal
-                  (if (instance? clojure.lang.PersistentArrayMap value1)
-                    (recur value1 value2)
-                    (= value1 value2))
-                  ))) true (keys map1))))
-
+  [coll]
+  (postwalk (fn
+              [value]
+              (if (instance? clojure.lang.IDeref value)
+                (soft-deref @value)
+                value)) coll))
 (defn
   #^{:doc "Generates a random UUID."}
   uuid

--- a/src/test/core.clj
+++ b/src/test/core.clj
@@ -7,5 +7,5 @@
     `(let [equal# (= ~actual ~expected)]
        (do
          (comment (when-not equal#
-                    (println "Actual:" ~actual "\nExpected:" ~expected)))
+                    (println "Actual:\t\t" ~actual "\nExpected:\t" ~expected)))
          (is (= ~actual ~expected) ~message)))))

--- a/src/utils/core.clj
+++ b/src/utils/core.clj
@@ -1,5 +1,5 @@
-(ns othello.utils
-  "Assorted utility functions. Might be moved out from Othello package later."
+(ns utils.core
+  "Assorted utility functions."
   (:use [clojure.test :only (deftest is are run-tests)]
         [clojure.repl :only (doc)]
         [clojure.walk :only (postwalk)]


### PR DESCRIPTION
Skrev om utils så att de blev mer generella.
Tog bort maps-equals och istället får man göra (= .. ..) själv med soft-deref som nu dereffar alla IDeref's som den hittar i den givna strukturen.
Flyttade othello.utils till utils.core nu istället.