### PR TITLE
Tests from 2500 msec -> 25 msec.

### DIFF
--- a/src/othello/mutator.clj
+++ b/src/othello/mutator.clj
@@ -204,7 +204,7 @@
                   (future (play-until-none-is-in-turn games game-id (first players) "B"))
                   (future (play-until-none-is-in-turn games game-id (first players) "C"))
                   (future (play-until-none-is-in-turn games game-id (second players) "D"))])
-    (time (doseq [f futures] (deref f 10000 "Stopped!\n")))
+    (doseq [f futures] (deref f 1000 "Stopped!\n"))
     (is= (:board (get-state (-get-game games game-id)))
          (core/simple-string->board "WWWWWWWB"
                                     "WWWBBWWB"


### PR DESCRIPTION
Tests from 2500 msec -> 25 msec. 
Now using internal -get-game and function. 
Also, get-state is not traversing whole states structure any more.

Jag tyckte att prefixet "-" var ganska nice för interna funktioner som krockar med en publik med samma namn.
Exempelvis ```-get-game``` är den interna varianten för ```get-game```.

Om det inte gilla kan vi byta till ```get-game-internal``` eller nåt liknande.
